### PR TITLE
Add other options to find RichPaths in RichPathView 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ RichPathAnimator.animate(richPath)
 
 #### 2. Find your richPath.
  ```java
+ // by path name
 RichPath richPath = richPathView.findRichPathByName("path_name");
-
+// or if it contains one path
+RichPath richPath = richPathView.findFirstRichPath();
+// or by index
+RichPath richPath = richPathView.findRichPathByIndex(0);
 ```
 
 #### 3. Use the RichPathAnimator to animate your richPath.

--- a/app/src/main/java/com/richpathanimator/sample/MainActivity.java
+++ b/app/src/main/java/com/richpathanimator/sample/MainActivity.java
@@ -22,6 +22,7 @@ public class MainActivity extends AppCompatActivity {
     private RichPathView playlistAddCheckRichPathView;
     private RichPathView loveFaceRichPathView;
     private RichPathView animalRichPathView;
+    private boolean reverse = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -130,7 +131,7 @@ public class MainActivity extends AppCompatActivity {
         String elephantPathData = getString(R.string.elephant_path);
         String bullPathData = getString(R.string.bull_path);
 
-        final RichPath richPath = animalRichPathView.findRichPathByName("path");
+        final RichPath richPath = animalRichPathView.findFirstRichPath();
 
         RichPathAnimator
                 .animate(richPath)
@@ -147,8 +148,6 @@ public class MainActivity extends AppCompatActivity {
 
                 .start();
     }
-
-    private boolean reverse = false;
 
     public void animateArrowToSearch(View view) {
 
@@ -181,8 +180,8 @@ public class MainActivity extends AppCompatActivity {
 
     public void animateNotification(View view) {
 
-        final RichPath top = notificationsRichPathView.findRichPathByName("top");
-        final RichPath bottom = notificationsRichPathView.findRichPathByName("bottom");
+        final RichPath top = notificationsRichPathView.findRichPathByIndex(0);
+        final RichPath bottom = notificationsRichPathView.findRichPathByIndex(1);
 
         RichPathAnimator.animate(top)
                 .interpolator(new DecelerateInterpolator())

--- a/app/src/main/res/drawable/animal.xml
+++ b/app/src/main/res/drawable/animal.xml
@@ -3,10 +3,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="34.08dp"
     android:height="24.08dp"
-    android:viewportWidth="409"
-    android:viewportHeight="280">
+    android:viewportHeight="280"
+    android:viewportWidth="409">
     <path
-        android:name="path"
-        android:pathData="@string/hippo_path"
-        android:fillColor="#FFF7F7F7"/>
+        android:fillColor="#FFF7F7F7"
+        android:pathData="@string/hippo_path" />
 </vector>

--- a/richpath/src/main/java/com/richpath/RichPathDrawable.java
+++ b/richpath/src/main/java/com/richpath/RichPathDrawable.java
@@ -89,6 +89,29 @@ class RichPathDrawable extends Drawable {
         return findRichPathByIndex(0);
     }
 
+    /**
+     * find {@link RichPath} by its index or null if not found
+     * <p>
+     * Note that the provided index must be the flattened index of the path
+     * <p>
+     * example:
+     * <pre>
+     * {@code <vector>
+     *     <path> // index = 0
+     *     <path> // index = 1
+     *     <group>
+     *          <path> // index = 2
+     *          <group>
+     *              <path> // index = 3
+     *          </group>
+     *      </group>
+     *      <path> // index = 4
+     *   </vector>}
+     * </pre>
+     *
+     * @param index the flattened index of the path
+     * @return the {@link RichPath} object found or null
+     */
     @Nullable
     public RichPath findRichPathByIndex(@IntRange(from = 0) int index) {
         if (vector == null || index < 0 || index >= vector.paths.size()) return null;

--- a/richpath/src/main/java/com/richpath/RichPathDrawable.java
+++ b/richpath/src/main/java/com/richpath/RichPathDrawable.java
@@ -77,6 +77,24 @@ class RichPathDrawable extends Drawable {
         return null;
     }
 
+    /**
+     * find the first {@link RichPath} or null if not found
+     * <p>
+     * This can be in handy if the vector consists of 1 path only
+     *
+     * @return the {@link RichPath} object found or null
+     */
+    @Nullable
+    public RichPath findFirstRichPath() {
+        return findRichPathByIndex(0);
+    }
+
+    @Nullable
+    public RichPath findRichPathByIndex(@IntRange(from = 0) int index) {
+        if (vector == null || index < 0 || index >= vector.paths.size()) return null;
+        return vector.paths.get(index);
+    }
+
     public void listenToPathsUpdates() {
 
         if (vector == null) return;

--- a/richpath/src/main/java/com/richpath/RichPathView.java
+++ b/richpath/src/main/java/com/richpath/RichPathView.java
@@ -5,6 +5,7 @@ import android.content.res.TypedArray;
 import android.content.res.XmlResourceParser;
 import android.graphics.Path;
 import android.support.annotation.DrawableRes;
+import android.support.annotation.IntRange;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.View;
@@ -133,9 +134,27 @@ public class RichPathView extends ImageView {
         setMeasuredDimension(width, height);
     }
 
+
     @Nullable
     public RichPath findRichPathByName(String name) {
         return richPathDrawable == null ? null : richPathDrawable.findRichPathByName(name);
+    }
+
+    /**
+     * find the first {@link RichPath} or null if not found
+     * <p>
+     * This can be in handy if the vector consists of 1 path only
+     *
+     * @return the {@link RichPath} object found or null
+     */
+    @Nullable
+    public RichPath findFirstRichPath() {
+        return richPathDrawable == null ? null : richPathDrawable.findFirstRichPath();
+    }
+
+    @Nullable
+    public RichPath findRichPathByIndex(@IntRange(from = 0) int index) {
+        return richPathDrawable == null ? null : richPathDrawable.findRichPathByIndex(index);
     }
 
     public void addPath(String path) {

--- a/richpath/src/main/java/com/richpath/RichPathView.java
+++ b/richpath/src/main/java/com/richpath/RichPathView.java
@@ -152,6 +152,29 @@ public class RichPathView extends ImageView {
         return richPathDrawable == null ? null : richPathDrawable.findFirstRichPath();
     }
 
+    /**
+     * find {@link RichPath} by its index or null if not found
+     * <p>
+     * Note that the provided index must be the flattened index of the path
+     * <p>
+     * example:
+     * <pre>
+     * {@code <vector>
+     *     <path> // index = 0
+     *     <path> // index = 1
+     *     <group>
+     *          <path> // index = 2
+     *          <group>
+     *              <path> // index = 3
+     *          </group>
+     *      </group>
+     *      <path> // index = 4
+     *   </vector>}
+     * </pre>
+     *
+     * @param index the flattened index of the path
+     * @return the {@link RichPath} object found or null
+     */
     @Nullable
     public RichPath findRichPathByIndex(@IntRange(from = 0) int index) {
         return richPathDrawable == null ? null : richPathDrawable.findRichPathByIndex(index);


### PR DESCRIPTION
Add other ways to find RichPaths : 
- `findFirstRichPath()` This can be useful if the vector has one path, so no need for searching by name and creating iterator for this.
- `findRichPathByIndex(int index)` This can be useful to find the paths in O(1) instead of O(n), This could be messy if the vector has many paths with complex structure, but it could be useful in cases like hamburger icon where the paths can be recognized easily by the index, This method returns null if the index out of bounds instead of throwing exception to match the existent `findRichPathByName` behavior.

I also updated couple of examples in the sample app to use them, and updated the code snippet in the readme file to include them. 