### PR TITLE
Fix interpolator method in AnimationBuilder

### DIFF
--- a/animator/src/main/java/com/richpathanimator/AnimationBuilder.java
+++ b/animator/src/main/java/com/richpathanimator/AnimationBuilder.java
@@ -122,7 +122,7 @@ public class AnimationBuilder {
     public AnimationBuilder interpolator(Interpolator interpolator) {
         this.interpolator = interpolator;
         for (ValueAnimator animator : animators) {
-            animator.setDuration(duration);
+            animator.setInterpolator(interpolator);
         }
         return this;
     }


### PR DESCRIPTION
Fix `AnimationBuilder.interpolator()` method to set the interpolator value instead of the duration.