### PR TITLE
Tweak the build to move common version numbers into the root project

### DIFF
--- a/animator/build.gradle
+++ b/animator/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.tarek360'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
 
@@ -25,10 +25,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestCompile("com.android.support.test.espresso:espresso-core:$espressoVersion", {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    testCompile 'junit:junit:4.12'
+    testCompile "junit:junit:$junitVersion"
 
     compile project(path: ':richpath')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
     defaultConfig {
         applicationId "com.pathanimator.sample"
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 3
         versionName "0.0.5"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -22,10 +22,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestCompile("com.android.support.test.espresso:espresso-core:$espressoVersion", {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    testCompile 'junit:junit:4.12'
+    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
+    testCompile "junit:junit:$junitVersion"
     compile project(path: ':animator')
 }

--- a/app/src/main/java/com/richpathanimator/sample/MainActivity.java
+++ b/app/src/main/java/com/richpathanimator/sample/MainActivity.java
@@ -29,13 +29,13 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        commandRichPathView = (RichPathView) findViewById(R.id.ic_command);
-        androidRichPathView = (RichPathView) findViewById(R.id.ic_android);
-        arrowSearchRichPathView = (RichPathView) findViewById(R.id.ic_arrow_search);
-        notificationsRichPathView = (RichPathView) findViewById(R.id.ic_notifications);
-        playlistAddCheckRichPathView = (RichPathView) findViewById(R.id.ic_playlist_add_check);
-        loveFaceRichPathView = (RichPathView) findViewById(R.id.love_face);
-        animalRichPathView = (RichPathView) findViewById(R.id.animal);
+        commandRichPathView = findViewById(R.id.ic_command);
+        androidRichPathView = findViewById(R.id.ic_android);
+        arrowSearchRichPathView = findViewById(R.id.ic_arrow_search);
+        notificationsRichPathView = findViewById(R.id.ic_notifications);
+        playlistAddCheckRichPathView = findViewById(R.id.ic_playlist_add_check);
+        loveFaceRichPathView = findViewById(R.id.love_face);
+        animalRichPathView = findViewById(R.id.animal);
 
         animateCommand();
     }

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,12 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 25
-    buildToolsVersion = '25.0.3'
-    minSdkVersion = 11
+    compileSdkVersion = 26
+    buildToolsVersion = '26.0.1'
+    minSdkVersion = 14
     targetSdkVersion = 25
 
-    supportLibraryVersion = '25.3.1'
+    supportLibraryVersion = '26.1.0'
     espressoVersion = '2.2.2'
     junitVersion = '4.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta6'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -15,10 +16,22 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven { url 'https://jitpack.io' }
 
     }
+}
+
+ext {
+    compileSdkVersion = 25
+    buildToolsVersion = '25.0.3'
+    minSdkVersion = 11
+    targetSdkVersion = 25
+
+    supportLibraryVersion = '25.3.1'
+    espressoVersion = '2.2.2'
+    junitVersion = '4.12'
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 07 10:58:43 EET 2017
+#Sat Sep 23 08:25:11 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/richpath/build.gradle
+++ b/richpath/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.tarek360'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         consumerProguardFiles 'consumer-proguard-rules.pro'
@@ -26,11 +26,11 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestCompile("com.android.support.test.espresso:espresso-core:$espressoVersion", {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile "com.android.support:support-v4:25.3.1"
+    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
 
-    testCompile 'junit:junit:4.12'
+    testCompile "junit:junit:$junitVersion"
 
 }


### PR DESCRIPTION
Makes it easier to update SDKs as you only have to do it in one place.